### PR TITLE
Use numpy version with not removed np.int

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<=1.23
 torch>=1.8.1
 torchvision>=0.9
 cnstd==1.2


### PR DESCRIPTION
`np.int` was deprecated in numpy 1.20 and removed in 1.24, while current version is 1.26

so project won't work with latest numpy

I fixed numpy version to latest with `np.int` support